### PR TITLE
not all installations uses 0770

### DIFF
--- a/DiceCaptcha/DiceCaptcha.module
+++ b/DiceCaptcha/DiceCaptcha.module
@@ -40,7 +40,7 @@ class DiceCaptcha extends WireData implements Module, ConfigurableModule
     {
         $this->$captchadir = $this->config->paths->assets . self::CAPTCHA_DIR;
         if (!is_dir($this->$captchadir)) {
-            mkdir($this->$captchadir, 0770);
+            mkdir($this->$captchadir, octdec(wire('config')->chmodDir));
         } else {
             //delete old files
             $files = glob($this->$captchadir . "/*");
@@ -146,4 +146,3 @@ class DiceCaptcha extends WireData implements Module, ConfigurableModule
     }
 }
 
-?>

--- a/DiceCaptcha/DiceCaptcha.module
+++ b/DiceCaptcha/DiceCaptcha.module
@@ -40,7 +40,7 @@ class DiceCaptcha extends WireData implements Module, ConfigurableModule
     {
         $this->$captchadir = $this->config->paths->assets . self::CAPTCHA_DIR;
         if (!is_dir($this->$captchadir)) {
-            mkdir($this->$captchadir, octdec(wire('config')->chmodDir));
+            wireMkdir($this->$captchadir);
         } else {
             //delete old files
             $files = glob($this->$captchadir . "/*");


### PR DESCRIPTION
you can get the individual setting as string from $config->chmodDir for directories or as string from $config->chmodFile for files. But we don't need to do this manually everytime, we can use wireMkdir($path). (https://github.com/ryancramerdesign/ProcessWire/blob/576a5d30153f045daa94a136a6ba981650632b26/wire/core/Functions.php#L216)

A closing PHP tag on the file end is not really necessary. You can use it, but you don't need to.

Nice Module! :)
